### PR TITLE
Group does not exist

### DIFF
--- a/scripts/create_user.sh
+++ b/scripts/create_user.sh
@@ -31,7 +31,7 @@ chmod 700 /home/"$USERNAME"/.ssh
 chmod 600 /home/"$USERNAME"/.ssh/authorized_keys
 
 # Change ownership of the .ssh directory and its contents
-chown -R "$USERNAME":"$USERNAME" /home/"$USERNAME"/.ssh
+chown -R "$USERNAME" /home/"$USERNAME"/.ssh
 
 # Configure sudo to not ask for a password for the new user
 echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/"$USERNAME"


### PR DESCRIPTION
### What's the issue?
When we execute the `create_user.sh` script, it tries to give ownership to the group $USERNAME but does not exist.

### What's the solution?
Simply give the ownership to the user and not a group.